### PR TITLE
Add Next.js dashboard and TTS endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ pytest_cache/
 
 # FastAPI/Starlette static files
 staticfiles/
+# Node
+node_modules/
+.next/
 
 # Ignore API keys and secrets
 *.env

--- a/API/api.py
+++ b/API/api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, UploadFile, File, Form
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from Agents.Discovery_Agent import DiscoveryAgent
 from Agents.Simplification_Agent import SimplificationAgent
@@ -135,6 +135,15 @@ async def clarify(
     )
     context_memory.append_to_list(f'{session_id}_clarifications', {'q': user_question, 'a': answer})
     return {"answer": answer}
+
+
+@app.post("/tts")
+async def tts(text: str = Form(...)):
+    """Convert text to speech using VoiceProcessingAgent and return audio."""
+    audio_path = voice_agent.text_to_speech(text)
+    if not audio_path:
+        return JSONResponse({"error": "TTS failed"}, status_code=500)
+    return FileResponse(audio_path, media_type="audio/mpeg", filename="speech.mp3")
 
 
 @app.get("/")

--- a/Dashboard/nextjs/next.config.js
+++ b/Dashboard/nextjs/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+module.exports = nextConfig

--- a/Dashboard/nextjs/package.json
+++ b/Dashboard/nextjs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-teacher-dashboard",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/Dashboard/nextjs/pages/_app.js
+++ b/Dashboard/nextjs/pages/_app.js
@@ -1,0 +1,3 @@
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/Dashboard/nextjs/pages/index.js
+++ b/Dashboard/nextjs/pages/index.js
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+
+export default function Home() {
+  const [prompt, setPrompt] = useState('')
+  const [response, setResponse] = useState(null)
+  const [clarify, setClarify] = useState('')
+  const [clarifyAnswer, setClarifyAnswer] = useState('')
+  const [audioUrl, setAudioUrl] = useState('')
+  const sessionId = 'default'
+
+  const handleTeach = async () => {
+    const formData = new FormData()
+    formData.append('user_prompt', prompt)
+    formData.append('session_id', sessionId)
+    const res = await fetch('http://127.0.0.1:8000/teach', {
+      method: 'POST',
+      body: formData
+    })
+    const data = await res.json()
+    setResponse(data)
+
+    const text = Object.values(data.engaged_lessons || data.lessons || {}).join('\n')
+    if (text) {
+      const ttsForm = new FormData()
+      ttsForm.append('text', text)
+      const ttsRes = await fetch('http://127.0.0.1:8000/tts', {
+        method: 'POST',
+        body: ttsForm
+      })
+      const blob = await ttsRes.blob()
+      setAudioUrl(URL.createObjectURL(blob))
+    }
+  }
+
+  const handleClarify = async () => {
+    if (!clarify || !response) return
+    const topic = Object.keys(response.engaged_lessons || response.lessons || {})[0]
+    const formData = new FormData()
+    formData.append('user_question', clarify)
+    formData.append('topic', topic)
+    formData.append('session_id', sessionId)
+    const res = await fetch('http://127.0.0.1:8000/clarify', {
+      method: 'POST',
+      body: formData
+    })
+    const data = await res.json()
+    setClarifyAnswer(data.answer)
+  }
+
+  return (
+    <div style={{padding: '40px', fontFamily: 'Arial, sans-serif'}}>
+      <h1>AI Teacher Dashboard</h1>
+      <input
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Ask a question"
+        style={{width: '60%', padding: '8px'}}
+      />
+      <button onClick={handleTeach} style={{marginLeft: '12px', padding: '8px 16px'}}>
+        Chat with Agent
+      </button>
+      {response && (
+        <div style={{marginTop: '30px'}}>
+          <h2>Response</h2>
+          <pre style={{background: '#f6f6fa', padding: '10px'}}>{JSON.stringify(response, null, 2)}</pre>
+          {audioUrl && (
+            <audio controls src={audioUrl} style={{marginTop: '10px'}} />
+          )}
+          <div style={{marginTop: '20px'}}>
+            <input
+              value={clarify}
+              onChange={e => setClarify(e.target.value)}
+              placeholder="Follow-up question"
+              style={{width: '60%', padding: '8px'}}
+            />
+            <button onClick={handleClarify} style={{marginLeft: '12px', padding: '8px 16px'}}>
+              Clarify
+            </button>
+            {clarifyAnswer && (
+              <p style={{marginTop: '10px'}}>{clarifyAnswer}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/Docs/Checklist.md
+++ b/Docs/Checklist.md
@@ -6,7 +6,7 @@
 
 * [ ] Create and initialize GitHub repo
 * [ ] Set up Python FastAPI backend (REST API server)
-* [ ] Set up basic HTML/JS frontend (input, output, play/record buttons)
+* [ ] Set up React + Next.js dashboard with voice controls
 
 ### **2. LLM & Agent Integration**
 
@@ -81,7 +81,7 @@
 
 ## **Potential Expansions (After MVP)**
 
-* [ ] Advanced dashboard UI (React/Vue, user stats, etc.)
+* [ ] Advanced dashboard features (analytics, user stats, etc.)
 * [ ] Adaptive learning paths and personalized progress tracking
 * [ ] Visual aids: real-time diagrams, code snippets, etc.
 * [ ] Cloud backend with load balancing/scalability


### PR DESCRIPTION
## Summary
- add minimal Next.js dashboard under `Dashboard/nextjs`
- update gitignore for node_modules and Next build
- implement `/tts` API endpoint using `VoiceProcessingAgent`
- update checklist to mention React + Next.js dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c3dab0e28832a801eb0a29669bc60