### PR TITLE
Add VisualIntelligence layer, API endpoint, and dashboard preview; update storyboard and docs

### DIFF
--- a/API/api.py
+++ b/API/api.py
@@ -12,6 +12,7 @@ from Agents.ContextMemory_Agent import ContextMemoryAgent
 from Agents.VoiceProcessing_Agent import VoiceProcessingAgent
 from Agents.VideoGenerationAgent import VideoGenerationAgent
 from Agents.StoryboardComposer_Agent import StoryboardComposer_Agent
+from Agents.VisualIntelligenceLayer_Agent import VisualIntelligenceLayer_Agent
 from Agents.Logger_Agent import LoggerAgent, set_current
 
 import openai
@@ -64,6 +65,7 @@ clarification_agent = ClarificationAgent(llm_fn=openai_llm)
 context_memory = ContextMemoryAgent()
 video_generation_agent = VideoGenerationAgent(voice_agent)
 storyboard_composer = StoryboardComposer_Agent(llm_fn=openai_llm)
+visual_intelligence_agent = VisualIntelligenceLayer_Agent(collector=storyboard_composer.fetcher)
 
 app = FastAPI()
 
@@ -241,6 +243,18 @@ async def _run_teach_pipeline(user_prompt, audio, session_id, video_minutes, ses
         "audio_folder": f"/output/audio/{session_name}/",
         "responce_txt_url": f"/output/response/{session_name}.txt",
         "log_url": f"/output/logs/{session_name}.log",
+    }
+
+
+@app.post("/visual-intelligence")
+async def visual_intelligence(
+    transcript: str = Form(...),
+    topic: str = Form(""),
+):
+    plan = visual_intelligence_agent.build_visual_plan(transcript=transcript, topic=topic)
+    return {
+        "chunk_count": len(plan),
+        "plan": plan,
     }
 
 

--- a/API/api.py
+++ b/API/api.py
@@ -65,7 +65,7 @@ clarification_agent = ClarificationAgent(llm_fn=openai_llm)
 context_memory = ContextMemoryAgent()
 video_generation_agent = VideoGenerationAgent(voice_agent)
 storyboard_composer = StoryboardComposer_Agent(llm_fn=openai_llm)
-visual_intelligence_agent = VisualIntelligenceLayer_Agent(collector=storyboard_composer.fetcher)
+visual_intelligence_agent = VisualIntelligenceLayer_Agent(collector=storyboard_composer.fetcher, llm_fn=openai_llm)
 
 app = FastAPI()
 

--- a/API/api.py
+++ b/API/api.py
@@ -13,6 +13,7 @@ from Agents.VoiceProcessing_Agent import VoiceProcessingAgent
 from Agents.VideoGenerationAgent import VideoGenerationAgent
 from Agents.StoryboardComposer_Agent import StoryboardComposer_Agent
 from Agents.VisualIntelligenceLayer_Agent import VisualIntelligenceLayer_Agent
+from Agents.SceneDirector_Agent import SceneDirector_Agent
 from Agents.Logger_Agent import LoggerAgent, set_current
 
 import openai
@@ -66,6 +67,7 @@ context_memory = ContextMemoryAgent()
 video_generation_agent = VideoGenerationAgent(voice_agent)
 storyboard_composer = StoryboardComposer_Agent(llm_fn=openai_llm)
 visual_intelligence_agent = VisualIntelligenceLayer_Agent(collector=storyboard_composer.fetcher, llm_fn=openai_llm)
+scene_director_agent = SceneDirector_Agent(llm_fn=openai_llm)
 
 app = FastAPI()
 
@@ -256,6 +258,18 @@ async def visual_intelligence(
         "chunk_count": len(plan),
         "plan": plan,
     }
+
+
+@app.post("/enhance-scenes")
+async def enhance_scenes(
+    scene_plan_json: str = Form(...),
+):
+    try:
+        scene_plan = json.loads(scene_plan_json)
+    except Exception:
+        return JSONResponse({"error": "scene_plan_json must be valid JSON"}, status_code=400)
+    enhanced = scene_director_agent.enhance(scene_plan)
+    return {"scene_count": len(enhanced), "scenes": enhanced}
 
 
 @app.post("/clarify")

--- a/Agents/SceneDirector_Agent.py
+++ b/Agents/SceneDirector_Agent.py
@@ -1,0 +1,127 @@
+import json
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+
+class SceneDirector_Agent:
+    """Enhances scene plans with stronger visual storytelling while preserving narration text."""
+
+    def __init__(self, llm_fn: Optional[Callable[[str], str]] = None):
+        self.llm_fn = llm_fn
+
+    def enhance(self, existing_scene_plan: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if not existing_scene_plan:
+            return []
+        if not self.llm_fn:
+            return [self._fallback_enhance(i, s) for i, s in enumerate(existing_scene_plan)]
+
+        prompt = self._prompt(existing_scene_plan)
+        raw = self.llm_fn(prompt)
+        try:
+            payload = self._parse_json(raw)
+            scenes = payload if isinstance(payload, list) else payload.get("scenes", [])
+            if not isinstance(scenes, list) or not scenes:
+                raise ValueError("No scenes")
+            # preserve original narration text strictly
+            return self._merge_preserve_text(existing_scene_plan, scenes)
+        except Exception:
+            return [self._fallback_enhance(i, s) for i, s in enumerate(existing_scene_plan)]
+
+    def _merge_preserve_text(self, original: List[Dict[str, Any]], enhanced: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        out = []
+        for i, src in enumerate(original):
+            e = enhanced[i] if i < len(enhanced) and isinstance(enhanced[i], dict) else {}
+            item = {**src, **e}
+            item["text"] = src.get("text", "")
+            out.append(item)
+        return out
+
+    def _fallback_enhance(self, idx: int, scene: Dict[str, Any]) -> Dict[str, Any]:
+        text = scene.get("text", "")
+        visual_type = self._infer_type(text)
+        emphasis = "highlight" if any(k in text.lower() for k in ["important", "key", "must", "critical"]) else "normal"
+        return {
+            **scene,
+            "visual_type": visual_type,
+            "background_query": self._background_query(visual_type, text),
+            "overlay_elements": self._overlay_for_type(visual_type, text),
+            "composition": {
+                "background_placement": "full-bleed cinematic background with depth blur",
+                "overlay_placement": "rule-of-thirds opposite speaker text",
+                "text_placement": "lower third with safe margins",
+            },
+            "animation": {
+                "entry": "soft fade + slight upward slide",
+                "motion": "slow push-in (2-4%) with parallax overlays",
+            },
+            "emphasis_level": emphasis,
+            "variation_strategy": "Alternates angle/motion/overlay density relative to previous scene",
+            "reasoning": "Maps narration meaning to distinct visual metaphor/literal elements while keeping readability.",
+        }
+
+    def _infer_type(self, text: str) -> str:
+        s = text.lower()
+        if any(k in s for k in ["certification", "tool", "dashboard", "interface"]):
+            return "literal"
+        if any(k in s for k in ["growth", "learn", "confused", "journey"]):
+            return "metaphor"
+        if any(k in s for k in ["click", "menu", "app", "screen", "ui"]):
+            return "ui"
+        return "abstract"
+
+    def _background_query(self, visual_type: str, text: str) -> str:
+        base = text[:90]
+        if visual_type == "metaphor":
+            return f"cinematic symbolic scene representing {base}, volumetric light, shallow depth of field"
+        if visual_type == "literal":
+            return f"high-detail real-world scene of {base}, documentary style, natural lighting"
+        if visual_type == "ui":
+            return f"modern product UI mockup for {base}, dark mode, clean grid, 4k"
+        return f"abstract motion graphics background for {base}, gradients, geometric depth"
+
+    def _overlay_for_type(self, visual_type: str, text: str) -> List[str]:
+        if visual_type == "metaphor":
+            return ["path/roadmap line", "milestone markers", "glow arrows"]
+        if visual_type == "literal":
+            return ["labeled object callouts", "context icons", "keyword badges"]
+        if visual_type == "ui":
+            return ["interface cards", "cursor highlight", "step indicators"]
+        return ["floating shape layers", "keyword chips", "soft data lines"]
+
+    def _prompt(self, plan: List[Dict[str, Any]]) -> str:
+        return (
+            "You are a senior video director and visual storytelling expert.\n\n"
+            "Your job is to enhance an existing video scene plan and make it highly engaging, visually rich, and logically aligned with narration.\n\n"
+            "STRICT RULES:\n"
+            "- Do NOT change narration text\n"
+            "- Improve visuals, composition, and storytelling\n"
+            "- Avoid generic stock visuals\n"
+            "- Add depth (layered scenes, motion, overlays)\n"
+            "- Ensure every visual clearly supports the meaning of narration\n"
+            "- Introduce variety across scenes (no repetition)\n\n"
+            "For EACH scene add:\n"
+            "1. visual_type (literal / metaphor / abstract / ui)\n"
+            "2. background_query\n"
+            "3. overlay_elements\n"
+            "4. composition {background placement, overlay placement, text placement}\n"
+            "5. animation {entry, motion}\n"
+            "6. emphasis_level (normal / highlight)\n"
+            "7. variation_strategy\n"
+            "8. reasoning\n\n"
+            "SPECIAL INSTRUCTIONS:\n"
+            "- For important sentences -> emphasis_level=highlight\n"
+            "- Use metaphor visuals for abstract ideas\n"
+            "- Use literal visuals for concrete terms\n"
+            "- Mix at least 2 visual types across scenes\n"
+            "- Avoid repeating the same type more than twice in a row\n\n"
+            "INPUT:\n" + json.dumps(plan, ensure_ascii=False) + "\n\n"
+            "OUTPUT: Enhanced structured JSON only."
+        )
+
+    @staticmethod
+    def _parse_json(raw: str) -> Any:
+        raw = raw.strip()
+        if raw.startswith("```"):
+            raw = re.sub(r"^```[a-zA-Z]*", "", raw).strip().rstrip("`").strip()
+        m = re.search(r"(\[.*\]|\{.*\})", raw, re.S)
+        return json.loads(m.group(1) if m else raw)

--- a/Agents/StoryboardComposer_Agent.py
+++ b/Agents/StoryboardComposer_Agent.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from Agents.SceneplannerAgent import SceneplannerAgent
 from Agents.AssetFetcher_Agent import AssetFetcher_Agent
 from Agents.LayoutEngine_Agent import LayoutEngine_Agent
+from Agents.VisualIntelligenceLayer_Agent import VisualIntelligenceLayer_Agent
 from Agents.Logger_Agent import get_current
 
 
@@ -21,6 +22,7 @@ class StoryboardComposer_Agent:
         self.planner = SceneplannerAgent(llm_fn=llm_fn)
         self.fetcher = AssetFetcher_Agent(cache_dir=cache_dir, per_keyword=per_keyword)
         self.layout = LayoutEngine_Agent()
+        self.visual_layer = VisualIntelligenceLayer_Agent(collector=self.fetcher)
 
     def close(self):
         self.fetcher.close()
@@ -49,8 +51,13 @@ class StoryboardComposer_Agent:
             if log: log.step_start(f"StoryboardComposer.scene[{idx}]",
                                    scene_id=scene.get("scene_id"),
                                    keywords=scene.get("keywords"))
+            scene_keywords = scene.get("keywords", [])
+            if len(scene_keywords) < 2:
+                extra = self.visual_layer.extract_keywords(scene.get("text", ""))[:3]
+                scene_keywords = list(dict.fromkeys([*scene_keywords, *extra]))
+
             assets = self.fetcher.fetch_for_scene(
-                keywords=scene.get("keywords", []),
+                keywords=scene_keywords,
                 visual_type=scene.get("visual_type", "illustration"),
                 topic=topic,
             )
@@ -61,7 +68,7 @@ class StoryboardComposer_Agent:
             composed.append({
                 "scene_id": scene["scene_id"],
                 "text": scene["text"],
-                "keywords": scene["keywords"],
+                "keywords": scene_keywords,
                 "visual_type": scene["visual_type"],
                 "duration": scene["duration"],
                 "start_time": round(cursor, 2),

--- a/Agents/StoryboardComposer_Agent.py
+++ b/Agents/StoryboardComposer_Agent.py
@@ -52,13 +52,16 @@ class StoryboardComposer_Agent:
                                    scene_id=scene.get("scene_id"),
                                    keywords=scene.get("keywords"))
             scene_keywords = scene.get("keywords", [])
+            scene_visual_type = scene.get("visual_type", "illustration")
             if len(scene_keywords) < 2:
-                extra = self.visual_layer.extract_keywords(scene.get("text", ""))[:3]
+                semantic = self.visual_layer.extract_semantic_data(scene.get("text", ""), topic=topic)
+                extra = semantic.get("keywords", [])[:3]
                 scene_keywords = list(dict.fromkeys([*scene_keywords, *extra]))
+                scene_visual_type = semantic.get("visual_type") or scene_visual_type
 
             assets = self.fetcher.fetch_for_scene(
                 keywords=scene_keywords,
-                visual_type=scene.get("visual_type", "illustration"),
+                visual_type=scene_visual_type,
                 topic=topic,
             )
             layout = self.layout.apply(scene, assets)
@@ -69,7 +72,7 @@ class StoryboardComposer_Agent:
                 "scene_id": scene["scene_id"],
                 "text": scene["text"],
                 "keywords": scene_keywords,
-                "visual_type": scene["visual_type"],
+                "visual_type": scene_visual_type,
                 "duration": scene["duration"],
                 "start_time": round(cursor, 2),
                 "end_time": round(cursor + scene["duration"], 2),

--- a/Agents/StoryboardComposer_Agent.py
+++ b/Agents/StoryboardComposer_Agent.py
@@ -4,6 +4,7 @@ from Agents.SceneplannerAgent import SceneplannerAgent
 from Agents.AssetFetcher_Agent import AssetFetcher_Agent
 from Agents.LayoutEngine_Agent import LayoutEngine_Agent
 from Agents.VisualIntelligenceLayer_Agent import VisualIntelligenceLayer_Agent
+from Agents.SceneDirector_Agent import SceneDirector_Agent
 from Agents.Logger_Agent import get_current
 
 
@@ -22,7 +23,8 @@ class StoryboardComposer_Agent:
         self.planner = SceneplannerAgent(llm_fn=llm_fn)
         self.fetcher = AssetFetcher_Agent(cache_dir=cache_dir, per_keyword=per_keyword)
         self.layout = LayoutEngine_Agent()
-        self.visual_layer = VisualIntelligenceLayer_Agent(collector=self.fetcher)
+        self.visual_layer = VisualIntelligenceLayer_Agent(collector=self.fetcher, llm_fn=llm_fn)
+        self.scene_director = SceneDirector_Agent(llm_fn=llm_fn)
 
     def close(self):
         self.fetcher.close()
@@ -81,10 +83,12 @@ class StoryboardComposer_Agent:
             })
             cursor += scene["duration"]
 
+        enhanced = self.scene_director.enhance(composed)
+
         return {
-            "scenes": composed,
+            "scenes": enhanced,
             "total_duration": round(cursor, 2),
-            "scene_count": len(composed),
+            "scene_count": len(enhanced),
         }
 
     @staticmethod

--- a/Agents/VisualIntelligenceLayer_Agent.py
+++ b/Agents/VisualIntelligenceLayer_Agent.py
@@ -1,0 +1,78 @@
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from Agents.AssetFetcher_Agent import AssetFetcher_Agent
+from Agents.Logger_Agent import get_current
+
+
+class VisualIntelligenceLayer_Agent:
+    """
+    Visual-intelligence pass that:
+    1) extracts reusable visual keywords from transcript text
+    2) builds compact scene-like chunks
+    3) queries the graphics collector (AssetFetcher_Agent)
+
+    Notes:
+    - AssetFetcher only uses free providers (Iconify/Openverse) or optionally-keyed
+      providers (Pexels/Unsplash) and keeps source metadata/license values.
+    - This layer is intentionally lightweight and deterministic so it can run even
+      when LLM calls are rate-limited.
+    """
+
+    STOPWORDS = {
+        "the", "a", "an", "and", "or", "to", "of", "in", "on", "for", "with", "as", "is", "are", "was", "were",
+        "be", "by", "that", "this", "it", "at", "from", "we", "you", "they", "i", "he", "she", "them", "our",
+        "their", "your", "can", "will", "would", "should", "could", "about", "into", "over", "under", "than",
+    }
+
+    def __init__(self, collector: Optional[AssetFetcher_Agent] = None, max_keywords: int = 6):
+        self.collector = collector or AssetFetcher_Agent()
+        self.max_keywords = max_keywords
+
+    def extract_keywords(self, transcript: str) -> List[str]:
+        words = re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", transcript.lower())
+        tokens = [w for w in words if w not in self.STOPWORDS and not w.isdigit()]
+        if not tokens:
+            return []
+        ranked = [w for w, _ in Counter(tokens).most_common(self.max_keywords * 2)]
+
+        # Preserve first-appearance order to keep semantic flow.
+        ordered: List[str] = []
+        seen = set()
+        for w in words:
+            if w in ranked and w not in seen:
+                ordered.append(w)
+                seen.add(w)
+            if len(ordered) >= self.max_keywords:
+                break
+        return ordered
+
+    def build_visual_plan(self, transcript: str, topic: str = "") -> List[Dict[str, Any]]:
+        log = get_current()
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", transcript or "") if s.strip()]
+        if not sentences:
+            return []
+
+        # Chunk every ~2 sentences for a compact plan.
+        chunks: List[str] = []
+        for i in range(0, len(sentences), 2):
+            chunks.append(" ".join(sentences[i:i + 2]))
+
+        output: List[Dict[str, Any]] = []
+        for idx, chunk in enumerate(chunks, start=1):
+            kws = self.extract_keywords(chunk)
+            if not kws:
+                kws = self.extract_keywords(transcript)[:3]
+            visual_type = "background" if idx % 3 == 0 else "illustration"
+            assets = self.collector.fetch_for_scene(kws, visual_type=visual_type, topic=topic)
+            output.append({
+                "chunk_id": idx,
+                "text": chunk,
+                "keywords": kws,
+                "visual_type": visual_type,
+                "assets": assets,
+            })
+            if log:
+                log.info("VisualIntelligenceLayer chunk planned", chunk_id=idx, keywords=kws, assets=len(assets))
+        return output

--- a/Agents/VisualIntelligenceLayer_Agent.py
+++ b/Agents/VisualIntelligenceLayer_Agent.py
@@ -1,43 +1,35 @@
+import json
 import re
 from collections import Counter
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from Agents.AssetFetcher_Agent import AssetFetcher_Agent
 from Agents.Logger_Agent import get_current
 
 
 class VisualIntelligenceLayer_Agent:
-    """
-    Visual-intelligence pass that:
-    1) extracts reusable visual keywords from transcript text
-    2) builds compact scene-like chunks
-    3) queries the graphics collector (AssetFetcher_Agent)
-
-    Notes:
-    - AssetFetcher only uses free providers (Iconify/Openverse) or optionally-keyed
-      providers (Pexels/Unsplash) and keeps source metadata/license values.
-    - This layer is intentionally lightweight and deterministic so it can run even
-      when LLM calls are rate-limited.
-    """
-
     STOPWORDS = {
         "the", "a", "an", "and", "or", "to", "of", "in", "on", "for", "with", "as", "is", "are", "was", "were",
         "be", "by", "that", "this", "it", "at", "from", "we", "you", "they", "i", "he", "she", "them", "our",
         "their", "your", "can", "will", "would", "should", "could", "about", "into", "over", "under", "than",
     }
 
-    def __init__(self, collector: Optional[AssetFetcher_Agent] = None, max_keywords: int = 6):
+    def __init__(
+        self,
+        collector: Optional[AssetFetcher_Agent] = None,
+        llm_fn: Optional[Callable[[str], str]] = None,
+        max_keywords: int = 6,
+    ):
         self.collector = collector or AssetFetcher_Agent()
+        self.llm_fn = llm_fn
         self.max_keywords = max_keywords
 
-    def extract_keywords(self, transcript: str) -> List[str]:
-        words = re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", transcript.lower())
+    def extract_keywords(self, text: str) -> List[str]:
+        words = re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", text.lower())
         tokens = [w for w in words if w not in self.STOPWORDS and not w.isdigit()]
         if not tokens:
             return []
         ranked = [w for w, _ in Counter(tokens).most_common(self.max_keywords * 2)]
-
-        # Preserve first-appearance order to keep semantic flow.
         ordered: List[str] = []
         seen = set()
         for w in words:
@@ -48,31 +40,165 @@ class VisualIntelligenceLayer_Agent:
                 break
         return ordered
 
+    def extract_semantic_data(self, text: str, topic: str = "") -> Dict[str, Any]:
+        fallback = {
+            "keywords": self.extract_keywords(text),
+            "intent": self._infer_intent(text),
+            "visual_type": self._visual_type_from_intent(self._infer_intent(text), []),
+            "priority": "high" if len(text) > 180 else "low",
+        }
+        if not self.llm_fn:
+            return fallback
+
+        prompt = (
+            "Extract visual-planning semantics as strict JSON with keys: "
+            "keywords(list[str], max 6), intent(str), visual_type(str from literal|diagram|metaphor|background|illustration), "
+            "priority(str high|low).\n"
+            f"Topic: {topic or 'general'}\nText: {text}"
+        )
+        try:
+            raw = self.llm_fn(prompt)
+            obj = self._json_from_text(raw)
+            kws = obj.get("keywords") if isinstance(obj.get("keywords"), list) else fallback["keywords"]
+            intent = str(obj.get("intent") or fallback["intent"])
+            visual_type = str(obj.get("visual_type") or self._visual_type_from_intent(intent, kws))
+            priority = str(obj.get("priority") or fallback["priority"])
+            return {
+                "keywords": [str(k).lower() for k in kws][: self.max_keywords],
+                "intent": intent,
+                "visual_type": visual_type,
+                "priority": "high" if priority.lower().startswith("h") else "low",
+            }
+        except Exception:
+            return fallback
+
+    def split_by_meaning(self, transcript: str) -> List[str]:
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", transcript or "") if s.strip()]
+        chunks: List[str] = []
+        current: List[str] = []
+        for s in sentences:
+            if self._starts_new_idea(s) and current:
+                chunks.append(" ".join(current))
+                current = [s]
+            else:
+                current.append(s)
+            if len(" ".join(current)) > 320:
+                chunks.append(" ".join(current))
+                current = []
+        if current:
+            chunks.append(" ".join(current))
+        return chunks
+
+    def build_visual_queries(self, topic: str, semantic: Dict[str, Any]) -> List[str]:
+        kws = semantic.get("keywords") or []
+        intent = semantic.get("intent", "explain")
+        visual_type = semantic.get("visual_type", "illustration")
+        queries = [f"{visual_type} {intent}"]
+        if kws:
+            queries.append(f"{kws[0]} {topic or intent}")
+        queries.append(f"{topic or 'education'} {intent} visual")
+        return [q.strip() for q in queries if q.strip()]
+
     def build_visual_plan(self, transcript: str, topic: str = "") -> List[Dict[str, Any]]:
         log = get_current()
-        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", transcript or "") if s.strip()]
-        if not sentences:
-            return []
-
-        # Chunk every ~2 sentences for a compact plan.
-        chunks: List[str] = []
-        for i in range(0, len(sentences), 2):
-            chunks.append(" ".join(sentences[i:i + 2]))
-
-        output: List[Dict[str, Any]] = []
+        chunks = self.split_by_meaning(transcript)
+        out: List[Dict[str, Any]] = []
         for idx, chunk in enumerate(chunks, start=1):
-            kws = self.extract_keywords(chunk)
-            if not kws:
-                kws = self.extract_keywords(transcript)[:3]
-            visual_type = "background" if idx % 3 == 0 else "illustration"
-            assets = self.collector.fetch_for_scene(kws, visual_type=visual_type, topic=topic)
-            output.append({
+            semantic = self.extract_semantic_data(chunk, topic=topic)
+            queries = self.build_visual_queries(topic, semantic)
+
+            assets: List[Dict[str, Any]] = []
+            for q in queries:
+                kws = [k for k in re.split(r"\s+", q) if k]
+                assets.extend(self.collector.fetch_for_scene(kws, semantic["visual_type"], topic=topic))
+                if len(assets) >= 10:
+                    break
+
+            ranked = self._rank_assets(assets, semantic["visual_type"], queries)
+            if len(ranked) < 2:
+                ranked.extend(self._generic_fallback_assets(semantic["intent"], topic))
+            ranked = ranked[:3]
+
+            out.append({
                 "chunk_id": idx,
                 "text": chunk,
-                "keywords": kws,
-                "visual_type": visual_type,
-                "assets": assets,
+                "keywords": semantic["keywords"],
+                "intent": semantic["intent"],
+                "priority": semantic["priority"],
+                "visual_type": semantic["visual_type"],
+                "queries": queries,
+                "assets": ranked,
             })
             if log:
-                log.info("VisualIntelligenceLayer chunk planned", chunk_id=idx, keywords=kws, assets=len(assets))
-        return output
+                log.info("VisualIntelligenceLayer chunk planned", chunk_id=idx, intent=semantic["intent"], assets=len(ranked))
+        return out
+
+    def _rank_assets(self, assets: List[Dict[str, Any]], visual_type: str, queries: List[str]) -> List[Dict[str, Any]]:
+        scored = []
+        qtokens = set(" ".join(queries).lower().split())
+        seen = set()
+        for a in assets:
+            url = a.get("url")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            title = str(a.get("title", "")).lower()
+            score = 0
+            if any(t in title for t in qtokens):
+                score += 2
+            atype = str(a.get("type", "")).lower()
+            if visual_type in atype or (visual_type == "diagram" and "icon" in atype):
+                score += 3
+            if a.get("width") and a.get("height"):
+                if int(a["width"]) >= 1000 or int(a["height"]) >= 1000:
+                    score += 1
+            scored.append((score, a))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [a for _, a in scored]
+
+    def _generic_fallback_assets(self, intent: str, topic: str) -> List[Dict[str, Any]]:
+        mapping = {
+            "growth": ["graph", "roadmap"],
+            "confusion": ["maze", "question"],
+            "learning": ["roadmap", "book"],
+        }
+        seed = []
+        for k, vals in mapping.items():
+            if k in intent.lower():
+                seed = vals
+                break
+        seed = seed or ["education", "concept"]
+        return self.collector.fetch_for_scene(seed, "illustration", topic=topic)[:2]
+
+    def _starts_new_idea(self, sentence: str) -> bool:
+        s = sentence.lower().strip()
+        markers = ("next", "now", "however", "on the other hand", "in contrast", "first", "second", "finally")
+        return any(s.startswith(m) for m in markers)
+
+    def _infer_intent(self, text: str) -> str:
+        s = text.lower()
+        if any(k in s for k in ["grow", "career", "improve", "increase"]):
+            return "growth"
+        if any(k in s for k in ["confused", "problem", "struggle", "challenge"]):
+            return "confusion"
+        if any(k in s for k in ["compare", "difference", "versus"]):
+            return "comparison"
+        return "explain"
+
+    def _visual_type_from_intent(self, intent: str, keywords: List[str]) -> str:
+        i = intent.lower()
+        if "growth" in i:
+            return "metaphor"
+        if "explain" in i or "comparison" in i:
+            return "diagram"
+        if any(k in {"device", "object", "tool", "cell", "atom"} for k in keywords):
+            return "literal"
+        return "illustration"
+
+    @staticmethod
+    def _json_from_text(raw: str) -> Dict[str, Any]:
+        raw = raw.strip()
+        if raw.startswith("```"):
+            raw = re.sub(r"^```[a-zA-Z]*", "", raw).strip().rstrip("`").strip()
+        match = re.search(r"\{.*\}", raw, re.S)
+        return json.loads(match.group(0) if match else raw)

--- a/Dashboard/dashboard.html
+++ b/Dashboard/dashboard.html
@@ -415,13 +415,6 @@
       }
     });
 
-    
-        const data = await r.json();
-        $('visualDump').textContent = JSON.stringify(data, null, 2);
-      } catch (e) {
-        $('visualDump').textContent = `Visual plan request failed: ${e}`;
-      }
-    });
 
   </script>
 </body>

--- a/Dashboard/dashboard.html
+++ b/Dashboard/dashboard.html
@@ -182,12 +182,6 @@
       </details>
     </div>
 
-    
-    <div id="visualCard" class="card">
-      <label>Visual Intelligence Preview <span class="hint">(extract keywords + fetch graphics)</span></label>
-      <button id="visualBtn" class="ghost" type="button">Generate visual plan</button>
-      <pre id="visualDump" style="margin-top:0.7em;">Run after entering a prompt or transcript.</pre>
-    </div>
 
     <div id="logCard" class="card hidden">
       <label style="margin-bottom: 0.6em;">Live log</label>
@@ -421,18 +415,7 @@
       }
     });
 
-    $('visualBtn').addEventListener('click', async () => {
-      const transcript = $('transcript').textContent?.trim() || $('prompt').value.trim();
-      if (!transcript) {
-        $('visualDump').textContent = 'Add a prompt first or generate a lesson so transcript exists.';
-        return;
-      }
-      $('visualDump').textContent = 'Loading visual plan...';
-      const fd = new FormData();
-      fd.append('transcript', transcript);
-      fd.append('topic', $('prompt').value.trim());
-      try {
-        const r = await fetch(`${API_BASE}/visual-intelligence`, { method: 'POST', body: fd });
+    
         const data = await r.json();
         $('visualDump').textContent = JSON.stringify(data, null, 2);
       } catch (e) {

--- a/Dashboard/dashboard.html
+++ b/Dashboard/dashboard.html
@@ -111,12 +111,14 @@
               padding: 0.8em; border-radius: 6px; margin-top: 0.6em; white-space: pre-wrap; }
 
     .hidden { display: none !important; }
+    .hero {background: linear-gradient(135deg,#111827,#0f172a 40%,#1d4ed8 140%);border:1px solid var(--border);padding:1em 1.2em;border-radius:14px;margin-bottom:1.1em;}
+    .kpi{display:inline-block;background:#0b1220;border:1px solid var(--border);padding:.35em .6em;border-radius:999px;margin-right:.4em;color:var(--muted);font-size:.8em;}
   </style>
 </head>
 <body>
   <div class="wrap">
-    <h1>AI Teacher</h1>
-    <p class="sub">Type a topic or upload a question — get a narrated, illustrated lesson video.</p>
+    <div class="hero"><h1>AI Teacher Studio</h1>
+    <p class="sub">Generate explainers, storyboard visuals, and classroom-ready videos from text or audio prompts.</p><span class="kpi">Multi-Agent</span><span class="kpi">Visual Intelligence</span><span class="kpi">FastAPI + Dashboard</span></div>
 
     <div class="card">
       <form id="teachForm" autocomplete="off">
@@ -178,6 +180,13 @@
         <summary>Pipeline output (topics, lessons)</summary>
         <pre id="pipelineDump"></pre>
       </details>
+    </div>
+
+    
+    <div id="visualCard" class="card">
+      <label>Visual Intelligence Preview <span class="hint">(extract keywords + fetch graphics)</span></label>
+      <button id="visualBtn" class="ghost" type="button">Generate visual plan</button>
+      <pre id="visualDump" style="margin-top:0.7em;">Run after entering a prompt or transcript.</pre>
     </div>
 
     <div id="logCard" class="card hidden">
@@ -411,6 +420,26 @@
         ans.innerHTML = `<div class="answer" style="border-left-color:var(--err);">Error: ${escapeHtml(err.message)}</div>`;
       }
     });
+
+    $('visualBtn').addEventListener('click', async () => {
+      const transcript = $('transcript').textContent?.trim() || $('prompt').value.trim();
+      if (!transcript) {
+        $('visualDump').textContent = 'Add a prompt first or generate a lesson so transcript exists.';
+        return;
+      }
+      $('visualDump').textContent = 'Loading visual plan...';
+      const fd = new FormData();
+      fd.append('transcript', transcript);
+      fd.append('topic', $('prompt').value.trim());
+      try {
+        const r = await fetch(`${API_BASE}/visual-intelligence`, { method: 'POST', body: fd });
+        const data = await r.json();
+        $('visualDump').textContent = JSON.stringify(data, null, 2);
+      } catch (e) {
+        $('visualDump').textContent = `Visual plan request failed: ${e}`;
+      }
+    });
+
   </script>
 </body>
 </html>

--- a/Docs/Agents_Deep_Dive.md
+++ b/Docs/Agents_Deep_Dive.md
@@ -1,0 +1,395 @@
+# TeacherAIAgent — Agent Deep Dive (Architecture, Responsibilities, Dependencies)
+
+This document explains every major agent in the repository, how each one works internally, how agents hand off to each other, and what dependencies each component uses.
+
+---
+
+## 1. System-wide pipeline overview
+
+At runtime, the app behaves as an agent pipeline orchestrated primarily by FastAPI routes in `API/api.py`.
+
+Primary lesson/video pipeline (`POST /teach`):
+1. Input ingestion (`user_prompt` text or uploaded `audio`)
+2. `DiscoveryAgent` (topic extraction and tiering)
+3. `SimplificationAgent` (convert topics into teachable steps)
+4. `TeachingAgent` (generate lesson content per step)
+5. `EngagingVideoTranscriptGeneratorAgent` (compose full script)
+6. `StoryboardComposer_Agent` (scenes + asset fetch + layout + scene enhancement)
+   - internally uses `SceneplannerAgent`, `AssetFetcher_Agent`, `LayoutEngine_Agent`, `VisualIntelligenceLayer_Agent`, `SceneDirector_Agent`
+7. `VideoGenerationAgent` (rendering + optional narration)
+8. `ContextMemoryAgent` persists artifacts for follow-up routes
+
+Support pipelines:
+- `POST /clarify`: `ClarificationAgent` + memory context
+- `POST /storyboard`: transcript -> storyboard JSON
+- `POST /visual-intelligence`: transcript -> visual plan (semantic chunking + assets)
+- `POST /enhance-scenes`: existing scene list -> director-style enriched scene metadata
+
+---
+
+## 2. Core orchestration (`API/api.py`)
+
+### Responsibilities
+- Initializes all agents once at process startup.
+- Hosts endpoints and transforms incoming form data into agent calls.
+- Persists and returns user-facing output references (video URL, response txt, log URL).
+- Mounts static dashboard and output folders.
+
+### Key dependencies
+- **FastAPI stack**: `fastapi`, `uvicorn`, `python-multipart`
+- **OpenAI SDK** for LLM function (`openai_llm`)
+- **dotenv** for env config
+- Standard libs: `os`, `json`, `glob`, `datetime`, etc.
+
+### Agent registry created in API layer
+- `VoiceProcessingAgent`
+- `DiscoveryAgent`
+- `SimplificationAgent`
+- `TeachingAgent`
+- `EngagingVideoTranscriptGeneratorAgent`
+- `ClarificationAgent`
+- `ContextMemoryAgent`
+- `VideoGenerationAgent`
+- `StoryboardComposer_Agent`
+- `VisualIntelligenceLayer_Agent`
+- `SceneDirector_Agent`
+
+---
+
+## 3. Agent-by-agent deep dive
+
+## 3.1 `DiscoveryAgent`
+
+### Purpose
+Parses a raw user request into structured topic tiers (main/supporting/background), giving downstream agents a hierarchical curriculum frame.
+
+### Inputs
+- text prompt (`input_type="text"`) OR transcribed prompt from audio path (`input_type="audio"`)
+
+### Outputs
+- Dictionary-like topic tier structure
+
+### Internal dependencies
+- `openai_llm` (LLM reasoning)
+- `VoiceProcessingAgent` for audio-driven flow
+
+### Why it matters
+It defines scope and reduces drift; all later agents depend on this decomposition quality.
+
+---
+
+## 3.2 `SimplificationAgent`
+
+### Purpose
+Transforms discovered tiers into concise, teachable steps.
+
+### Inputs
+- Topic-tier object from `DiscoveryAgent`
+
+### Outputs
+- Simplified plan keyed by topic
+
+### Dependencies
+- `openai_llm`
+
+### Why it matters
+Prevents over-dense lesson text and makes teaching output easier to narrate and visualize.
+
+---
+
+## 3.3 `TeachingAgent`
+
+### Purpose
+Generates fuller instructional content for each simplified step.
+
+### Inputs
+- Simplified step plan
+
+### Outputs
+- Lesson map (`topic -> lesson text`)
+
+### Dependencies
+- `openai_llm`
+
+### Why it matters
+Produces domain content later transformed into transcript and scene-level visuals.
+
+---
+
+## 3.4 `EngagingVideoTranscriptGeneratorAgent`
+
+### Purpose
+Builds a continuous narration script optimized for target video length.
+
+### Inputs
+- Lesson map
+- Duration constraints (`video_minutes`)
+
+### Outputs
+- Single transcript string suitable for TTS + scene planning
+
+### Dependencies
+- `openai_llm`
+
+### Why it matters
+Transcript quality drives both visual planning and pacing.
+
+---
+
+## 3.5 `VoiceProcessingAgent`
+
+### Purpose
+Provides speech-related capabilities:
+- STT for audio input mode
+- TTS for narration output in video generation
+
+### Dependencies
+- `openai-whisper` (local STT)
+- `elevenlabs` SDK (TTS)
+- audio stack (`soundfile`, etc.)
+
+### Operational notes
+- Handles provider/API errors and key/voice availability constraints.
+
+---
+
+## 3.6 `ContextMemoryAgent`
+
+### Purpose
+Stores and retrieves per-session artifacts:
+- user input
+- topic tiers
+- simplified steps
+- lessons
+- transcript
+- clarify history
+
+### Dependencies
+- `chromadb`
+
+### Why it matters
+Enables contextual clarifications and continuity across endpoint calls.
+
+---
+
+## 3.7 `ClarificationAgent`
+
+### Purpose
+Answers follow-up questions grounded in generated lesson context and prior history.
+
+### Inputs
+- user question
+- selected topic
+- memory context + clarifications
+
+### Outputs
+- text answer
+
+### Dependencies
+- `openai_llm`
+- `ContextMemoryAgent` data
+
+---
+
+## 3.8 `SceneplannerAgent`
+
+### Purpose
+Converts transcript text into timed scene units (text, duration, keywords, visual intent hints).
+
+### Dependencies
+- `openai_llm`
+
+### Why it matters
+Defines the scene skeleton consumed by fetch/layout/director agents.
+
+---
+
+## 3.9 `AssetFetcher_Agent` (graphics collector)
+
+### Purpose
+Retrieves visuals from free/legal-friendly sources, ranks candidates, deduplicates URLs, and caches local assets.
+
+### Provider strategy
+- Keyless providers: Iconify, Openverse
+- Optional-key providers: Pexels, Unsplash
+
+### Inputs
+- scene keywords
+- visual type
+- topic context
+
+### Outputs
+- ranked asset list with provider metadata and local cache paths when downloaded
+
+### Dependencies
+- `httpx` for provider APIs
+- provider keys from environment when available
+- local file/cache operations
+
+### Why it matters
+This is the main legal-safe media retrieval layer used by storyboard/visual intelligence.
+
+---
+
+## 3.10 `LayoutEngine_Agent`
+
+### Purpose
+Builds screen layout instructions from scene text + selected assets.
+
+### Outputs
+- layout blocks and placement information consumed by rendering pipeline
+
+### Why it matters
+Bridges raw assets and final composited frame structure.
+
+---
+
+## 3.11 `VisualIntelligenceLayer_Agent`
+
+### Purpose
+Performs transcript-driven semantic visual planning.
+
+### Main functions
+- fallback keyword extraction
+- semantic extraction (LLM-first, heuristic fallback)
+- meaning-aware chunking
+- intent-to-visual query construction
+- asset ranking and fallback selection
+
+### Inputs
+- transcript text
+- optional topic
+
+### Outputs
+- chunked visual plan entries containing keywords, intent, visual type, queries, and assets
+
+### Dependencies
+- `AssetFetcher_Agent`
+- optional `openai_llm`
+
+### Why it matters
+Improves semantic alignment between narration and visual search compared to pure token frequency.
+
+---
+
+## 3.12 `SceneDirector_Agent`
+
+### Purpose
+Enhances scene metadata into director-style storytelling instructions without changing narration text.
+
+### Adds per scene
+- `visual_type`
+- `background_query`
+- `overlay_elements`
+- `composition`
+- `animation`
+- `emphasis_level`
+- `variation_strategy`
+- `reasoning`
+
+### Modes
+- LLM-enhanced structured JSON path
+- deterministic fallback path
+
+### Why it matters
+Raises visual quality and scene variety beyond basic storyboard metadata.
+
+---
+
+## 3.13 `StoryboardComposer_Agent`
+
+### Purpose
+Orchestrates scene planning, asset retrieval, layout generation, and director enhancement into one structured storyboard JSON.
+
+### Internal orchestration
+1. plan scenes (`SceneplannerAgent`)
+2. apply duration budget cap
+3. enrich sparse scene keywords/type (`VisualIntelligenceLayer_Agent`)
+4. fetch assets (`AssetFetcher_Agent`)
+5. apply layout (`LayoutEngine_Agent`)
+6. enhance full scene list (`SceneDirector_Agent`)
+
+### Why it matters
+This is the central visual orchestration engine before rendering.
+
+---
+
+## 3.14 `VideoGenerationAgent`
+
+### Purpose
+Renders final media outputs from script/storyboard:
+- frame composition
+- animation/motion assembly
+- narration/audio composition
+- mp4 export
+
+### Dependencies
+- `moviepy`
+- image/audio libs (`pillow`, etc.)
+- `VoiceProcessingAgent` for narration audio
+
+---
+
+## 3.15 `Logger_Agent`
+
+### Purpose
+Session-scoped structured logging for UI tailing and pipeline diagnostics.
+
+### Why it matters
+Powers `/log_tail/{session}` and helps detect agent-step failures quickly.
+
+---
+
+## 4. Dependency matrix (high-level)
+
+- LLM reasoning: `openai`
+- STT: `openai-whisper`, `torch`, `numpy`
+- TTS: `elevenlabs`
+- API server: `fastapi`, `uvicorn`, `python-multipart`
+- Memory: `chromadb`
+- Media retrieval: `httpx`
+- Video rendering: `moviepy`, `pillow`, audio/image stack
+- Config/runtime: `python-dotenv`
+
+---
+
+## 5. Failure handling model
+
+- Missing provider keys: optional providers are skipped gracefully.
+- Asset fetch misses: fallback assets are returned.
+- LLM parse failures in visual agents: deterministic fallback paths run.
+- Voice/TTS failures: logged and surfaced via API errors.
+- Route-level exceptions: wrapped into JSON error responses with log URLs.
+
+---
+
+## 6. How agents work together “in practice”
+
+Example request (`POST /teach`):
+1. User asks: “Explain cybersecurity certifications for beginners.”
+2. Discovery tiers topics.
+3. Simplification creates sequence (why certs, path, prep strategy).
+4. Teaching drafts full lesson blocks.
+5. Transcript agent generates one continuous script for target minutes.
+6. Storyboard composer slices script into scenes, enriches semantics, fetches assets, applies layouts, and applies scene direction enhancement.
+7. Video generation renders animation + audio output.
+8. Context saves everything for follow-up clarifications.
+
+Result: user receives playable video URL, transcript, logs, and a stateful session that supports Q&A.
+
+---
+
+## 7. Operational tips
+
+- If visuals are weak, inspect `/visual-intelligence` output for queries/intent.
+- If rendering fails, inspect session logs via `/log_tail` + output log file.
+- Keep environment keys configured for best asset diversity and narration quality.
+- For deterministic debugging, run with fallback paths and compare outputs.
+
+---
+
+## 8. Related docs
+
+- `README.md` (quickstart + endpoint summary)
+- `Docs/Complete_App_Guide.md` (product-level architecture)
+- `UPGRADE_NOTES.md` (dependency/runtime upgrade notes)

--- a/Docs/Complete_App_Guide.md
+++ b/Docs/Complete_App_Guide.md
@@ -102,7 +102,17 @@ Returns:
 - `chunk_count`
 - `plan[]` with chunk text, extracted keywords, visual type, assets.
 
-## 4.4 `POST /clarify`
+## 4.4 `POST /enhance-scenes`
+Enhance an existing scene plan into director-grade visual storytelling metadata.
+
+Form fields:
+- `scene_plan_json` (required JSON string list of scenes)
+
+Returns:
+- `scene_count`
+- `scenes[]` enhanced scenes preserving narration text
+
+## 4.5 `POST /clarify`
 Ask follow-up questions grounded in session context.
 
 Form fields:
@@ -113,7 +123,7 @@ Form fields:
 Returns:
 - `answer`
 
-## 4.5 `GET /` and `GET /api/health`
+## 4.6 `GET /` and `GET /api/health`
 - `/`: dashboard file response (or status JSON fallback)
 - `/api/health`: service health JSON
 

--- a/Docs/Complete_App_Guide.md
+++ b/Docs/Complete_App_Guide.md
@@ -1,0 +1,154 @@
+# TeacherAIAgent — Complete Architecture & Product Guide
+
+## 1) What this app does
+TeacherAIAgent turns a user prompt (or uploaded audio question) into a complete teaching experience:
+- topic discovery and decomposition
+- simplified lesson steps
+- full teaching script/transcript generation
+- storyboard creation with visuals
+- video generation with optional narration
+- follow-up clarification Q&A
+- visual-intelligence planning for keyword-driven legal/free graphics retrieval
+
+The app includes:
+- **FastAPI backend** (`API/api.py`)
+- **Agent modules** (`Agents/*.py`)
+- **Web frontend dashboard** (`Dashboard/dashboard.html`)
+- **Output artifacts** (video, frames, audio, logs, responses under `output/`)
+
+---
+
+## 2) Architecture
+
+## 2.1 High-level flow
+1. Client sends request to backend (`/teach`, `/storyboard`, or `/visual-intelligence`).
+2. Backend orchestrates agents for topic analysis, script creation, and visuals.
+3. Video pipeline renders frames + narration into MP4.
+4. Frontend streams results, logs, and follow-up clarification.
+
+## 2.2 Agent pipeline (primary)
+1. **DiscoveryAgent**: parses user intent into topic tiers.
+2. **SimplificationAgent**: turns tiers into teachable step lists.
+3. **TeachingAgent**: generates detailed lesson content.
+4. **EngagingVideoTranscriptGeneratorAgent**: composes a full video script.
+5. **StoryboardComposer_Agent**: builds scenes with timings + visual assets + layout.
+6. **VideoGenerationAgent**: produces output video/audio assets.
+7. **ClarificationAgent**: answers follow-up questions using saved context.
+8. **ContextMemoryAgent**: persists session state.
+
+## 2.3 Visual intelligence layer
+`VisualIntelligenceLayer_Agent` adds transcript-first visual planning:
+- extracts compact visual keywords from transcript chunks
+- generates chunk-level visual plans
+- calls `AssetFetcher_Agent` (graphics collector) to retrieve relevant assets
+
+Graphics sources are pulled via existing provider logic in `AssetFetcher_Agent`:
+- keyless: Iconify, Openverse
+- optional keys: Pexels, Unsplash
+
+---
+
+## 3) Frontend
+
+The dashboard (single-page HTML/CSS/JS) provides:
+- text or audio lesson input
+- duration/session/animation controls
+- video playback + download
+- transcript and pipeline JSON views
+- live log tailing
+- follow-up clarification form
+- visual-intelligence plan explorer
+
+It is mounted by FastAPI and served at:
+- `/` (if dashboard exists)
+- `/dashboard` static mount
+
+---
+
+## 4) API Endpoints
+
+## 4.1 `POST /teach`
+Generate the full lesson + optional video.
+
+Form fields:
+- `user_prompt` (optional if `audio` provided)
+- `audio` (optional if `user_prompt` provided)
+- `session_id` (default: `default`)
+- `video_minutes` (default: 8)
+- `animated` (`true/false`)
+- `silent` (`true/false`)
+
+Returns:
+- topic tiers, simplified steps, lessons, generated script, output paths, logs.
+
+## 4.2 `POST /storyboard`
+Generate storyboard JSON.
+
+Form fields:
+- `transcript` OR `user_prompt`
+- `video_minutes` (optional)
+
+Returns:
+- scene list with timing, assets, and layout blocks.
+
+## 4.3 `POST /visual-intelligence`
+Generate transcript-driven visual plan.
+
+Form fields:
+- `transcript` (required)
+- `topic` (optional)
+
+Returns:
+- `chunk_count`
+- `plan[]` with chunk text, extracted keywords, visual type, assets.
+
+## 4.4 `POST /clarify`
+Ask follow-up questions grounded in session context.
+
+Form fields:
+- `user_question`
+- `topic`
+- `session_id`
+
+Returns:
+- `answer`
+
+## 4.5 `GET /` and `GET /api/health`
+- `/`: dashboard file response (or status JSON fallback)
+- `/api/health`: service health JSON
+
+---
+
+## 5) Running locally
+1. `uv sync`
+2. Set `.env` vars: `OPENAI_API_KEY` (+ optional `PEXELS_API_KEY`, `UNSPLASH_ACCESS_KEY`, `ELEVENLABS_API_KEY`).
+3. `uv run uvicorn API.api:app --reload`
+4. Open `http://127.0.0.1:8000/`
+
+---
+
+## 6) Output layout
+- `output/video/<session>/...mp4`
+- `output/audio/<session>/...`
+- `output/frames/<session>/...`
+- `output/logs/<session>.log`
+- `output/response/<session>.txt`
+
+---
+
+## 7) What it can do today
+- teach any topic from text or voice prompt
+- create short/long narrated educational videos
+- generate storyboard scenes with timed visual assets
+- fetch relevant graphics from free/legal-friendly providers
+- answer session-aware clarifying questions
+- expose debug-friendly visual plan endpoint for product integrations
+
+---
+
+## 8) Suggested next enhancements
+- user auth + saved course history
+- chapter-level editing and re-render
+- stricter license policy controls by endpoint parameter
+- analytics dashboard (completion time, topic retention)
+- multi-language lesson and subtitle tracks

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TeacherAIAgent is a multi-agent teaching platform that converts a prompt (or voi
 - **Frontend:** Dashboard UI in `Dashboard/dashboard.html`
 - **Outputs:** saved under `output/`
 
-Detailed documentation: **`Docs/Complete_App_Guide.md`**.
+Detailed documentation: **`Docs/Complete_App_Guide.md`** and **`Docs/Agents_Deep_Dive.md`**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,107 +1,69 @@
 # TeacherAIAgent
 
-TeacherAIAgent is an AI-powered teaching assistant platform that helps break down complex topics, generate structured lessons, answer clarifying questions, and even process voice input. It leverages large language models (LLMs) and modular agents to deliver a personalized, interactive learning experience.
+TeacherAIAgent is a multi-agent teaching platform that converts a prompt (or voice query) into structured lessons, storyboarded visuals, and optional narrated video.
 
-## Features
+## Core capabilities
+- Topic discovery and decomposition
+- Lesson simplification and teaching generation
+- Full transcript/script generation for target duration
+- Storyboard planning (scenes, keywords, visual type, timing)
+- Graphics collection from free/legal-friendly providers
+- Video generation with optional TTS narration
+- Clarification Q&A with session memory
+- Browser dashboard for end-to-end usage
 
-- **Topic Discovery:** Breaks down user prompts into structured learning objectives (tiers).
-- **Simplification:** Simplifies complex topics into step-by-step learning paths.
-- **Lesson Generation:** Creates detailed lessons for each learning step.
-- **Engagement:** Enhances lessons with analogies, examples, and interactive elements.
-- **Clarification:** Answers follow-up questions and provides further explanations.
-- **Voice Input:** Accepts both text and audio (speech-to-text) prompts.
-- **Session Memory:** Remembers user sessions and context for continuity.
-- **REST API:** FastAPI-based backend for easy integration.
+## Architecture at a glance
+- **Backend:** FastAPI (`API/api.py`)
+- **Agents:** Modular pipeline in `Agents/`
+- **Frontend:** Dashboard UI in `Dashboard/dashboard.html`
+- **Outputs:** saved under `output/`
 
-## Folder Structure
+Detailed documentation: **`Docs/Complete_App_Guide.md`**.
 
-```
-Agents/           # Core agent modules (Discovery, Teaching, VoiceProcessing, etc.)
-API/              # FastAPI backend
-Dashboard/        # (Optional) Frontend dashboard
-Docs/             # Documentation and checklists
-output/           # Generated audio, video, and response files
-requirements.txt  # Python dependencies
-main.py           # (Entry point, if used)
-```
+---
 
-## Setup
+## API endpoints
+- `POST /teach` — full pipeline (prompt/audio -> lesson + video)
+- `POST /storyboard` — storyboard JSON generation
+- `POST /visual-intelligence` — transcript-driven keyword/asset plan
+- `POST /clarify` — follow-up Q&A
+- `GET /` — serves dashboard
+- `GET /api/health` — health status
 
-1. **Clone the repository:**
-   ```sh
-   git clone https://github.com/SlayerK15/TeacherAIAgent.git
-   cd TeacherAIAgent
-   ```
-2. **Create and activate a virtual environment:**
-   ```sh
-   python -m venv venv
-   # On Windows:
-   venv\Scripts\activate
-   # On Unix/Mac:
-   source venv/bin/activate
-   ```
-3. **Install deps with uv:**
-   ```sh
-   uv sync
-   ```
-4. **Set your OpenAI API key:**
-   - Set the `OPENAI_API_KEY` environment variable. Optional: `PEXELS_API_KEY`, `UNSPLASH_ACCESS_KEY`.
+---
 
-5. **Run the API server:**
-   ```sh
-   uv run uvicorn API.api:app --reload
-   ```
-
-6. **New endpoint — structured storyboard:**
-   ```sh
-   curl -X POST http://localhost:8000/storyboard -F "user_prompt=Explain photosynthesis" -F "video_minutes=2"
-   ```
-
-## Usage
-
-### Teach Endpoint
-- **POST** `/teach`
-- Accepts: `user_prompt` (text) or `audio` (file)
-- Returns: Topic tiers, simplified steps, lessons, and engaged lessons
-
-Example (using `curl`):
-```sh
-curl -X POST "http://localhost:8000/teach" -F "user_prompt=Explain quantum computing"
+## Quickstart
+```bash
+uv sync
 ```
 
-### Clarify Endpoint
-- **POST** `/clarify`
-- Accepts: `user_question`, `topic`, `session_id`
-- Returns: Clarification/answer
+Set environment variables in `.env`:
+- `OPENAI_API_KEY` (required)
+- `ELEVENLABS_API_KEY` (for narration)
+- `PEXELS_API_KEY` (optional)
+- `UNSPLASH_ACCESS_KEY` (optional)
 
-Example:
-```sh
-curl -X POST "http://localhost:8000/clarify" -F "user_question=What is a qubit?" -F "topic=Quantum Computing"
+Run server:
+```bash
+uv run uvicorn API.api:app --reload
 ```
 
-## Agents Overview
-- **DiscoveryAgent:** Breaks down prompts into learning tiers (main, supporting, background topics).
-- **SimplificationAgent:** Simplifies topics into actionable steps.
-- **TeachingAgent:** Generates lessons for each step.
-- **EngagementAgent:** Adds engagement (examples, analogies).
-- **ClarificationAgent:** Answers follow-up questions.
-- **VoiceProcessingAgent:** Converts speech (audio) to text.
-- **ContextMemoryAgent:** Stores and retrieves session data.
+Open:
+- `http://127.0.0.1:8000/`
 
-## Audio Input
-- Send an audio file (e.g., `.wav`, `.mp3`) to `/teach` as the `audio` field.
-- The system will transcribe and process it as a prompt.
+---
 
-## Output
-- Generated audio, video, and response files are saved in the `output/` directory.
+## Frontend included
+The built-in dashboard supports:
+- text/audio input modes
+- animation/silent toggles
+- transcript and pipeline dump views
+- live logs
+- follow-up clarification
+- visual intelligence plan preview
 
-## Development
-- All agents are modular and can be extended or replaced.
-- See `Docs/` for checklists and POC notes.
+---
 
-## License
-This project is for educational and research purposes. See `LICENSE` for details.
-
-## Acknowledgments
-- Powered by OpenAI GPT models
-- Built with FastAPI
+## Notes
+- This repository is intended for educational/research usage.
+- See `UPGRADE_NOTES.md` for latest dependency/runtime upgrades.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Detailed documentation: **`Docs/Complete_App_Guide.md`**.
 - `POST /storyboard` — storyboard JSON generation
 - `POST /visual-intelligence` — transcript-driven keyword/asset plan
 - `POST /clarify` — follow-up Q&A
+- `POST /enhance-scenes` — director-grade scene enhancement JSON
 - `GET /` — serves dashboard
 - `GET /api/health` — health status
 

--- a/test_scene_director.py
+++ b/test_scene_director.py
@@ -1,0 +1,9 @@
+from Agents.SceneDirector_Agent import SceneDirector_Agent
+
+
+def test_scene_director_preserves_text_and_adds_fields():
+    plan = [{"scene_id": 1, "text": "Certifications help career growth."}]
+    out = SceneDirector_Agent(llm_fn=None).enhance(plan)
+    assert out[0]["text"] == plan[0]["text"]
+    for k in ["visual_type", "background_query", "overlay_elements", "composition", "animation", "emphasis_level", "variation_strategy", "reasoning"]:
+        assert k in out[0]

--- a/test_visual_intelligence.py
+++ b/test_visual_intelligence.py
@@ -1,0 +1,25 @@
+from Agents.VisualIntelligenceLayer_Agent import VisualIntelligenceLayer_Agent
+
+
+class StubCollector:
+    def fetch_for_scene(self, keywords, visual_type, topic=""):
+        return [
+            {"url": f"http://x/{'-'.join(keywords[:2])}", "title": "career growth roadmap", "type": "image", "width": 1200, "height": 800},
+            {"url": f"http://y/{visual_type}", "title": "generic visual", "type": visual_type},
+        ]
+
+
+def test_extract_semantic_data_fallback():
+    a = VisualIntelligenceLayer_Agent(collector=StubCollector(), llm_fn=None)
+    s = a.extract_semantic_data("I want to grow my cybersecurity career and improve skills")
+    assert s["intent"] == "growth"
+    assert s["visual_type"] in {"metaphor", "diagram", "illustration", "literal"}
+    assert len(s["keywords"]) > 0
+
+
+def test_build_visual_plan_has_queries_and_assets():
+    a = VisualIntelligenceLayer_Agent(collector=StubCollector(), llm_fn=None)
+    plan = a.build_visual_plan("First we explain basics. Next we compare career paths and improve outcomes.", topic="cybersecurity")
+    assert len(plan) >= 1
+    assert "queries" in plan[0]
+    assert len(plan[0]["assets"]) >= 1


### PR DESCRIPTION
### Motivation
- Provide a lightweight, deterministic visual-intelligence pass to extract scene-level keywords and fetch legal/free graphics without relying on LLMs for all visual planning.
- Expose a developer-friendly API and dashboard preview so users can inspect visual plans separate from the full teach/video pipeline.
- Improve storyboard asset selection by augmenting scenes with extracted keywords when planner output is sparse and document the full app flow.

### Description
- Add `Agents/VisualIntelligenceLayer_Agent.py` implementing `extract_keywords` and `build_visual_plan`, and using `AssetFetcher_Agent` to retrieve assets for keyword-driven chunks.
- Integrate the visual layer into `Agents/StoryboardComposer_Agent.py` by instantiating `self.visual_layer` and augmenting scene keyword lists when fewer than two keywords are present.
- Add a new FastAPI endpoint `POST /visual-intelligence` in `API/api.py`, instantiate `visual_intelligence_agent = VisualIntelligenceLayer_Agent(collector=storyboard_composer.fetcher)`, and return chunked visual plans as JSON.
- Update `Dashboard/dashboard.html` to add a Visual Intelligence preview card, a `Generate visual plan` button, and client-side JS to call the new endpoint, and refresh the hero/branding copy.
- Add a comprehensive `Docs/Complete_App_Guide.md` and update `README.md` to reflect the new features and usage notes.

### Testing
- No automated tests were added to cover the new visual layer or endpoint.
- No automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12eb9d580832aaf472a38f42db713)